### PR TITLE
Add "set -e" to tag-and-push.sh so we quit early if building fails

### DIFF
--- a/ddev-seed/tag-and-push.sh
+++ b/ddev-seed/tag-and-push.sh
@@ -1,3 +1,5 @@
+#/bin/bash
+set -e
 docker image tag ddev_ui:latest  $MY_DOCKER_ID/ddev_ui:1.0
 docker image tag ddev_api:latest $MY_DOCKER_ID/ddev_api:1.0
 docker image tag ddev_db:latest  $MY_DOCKER_ID/ddev_db:1.0


### PR DESCRIPTION
In the tag-and-push.sh script, if the tagging fails, (because `:latest` wasn't build properly), but 1.0 still existed, that old version would get pushed to the Hub. One of my students ran into this, and it took us a while to figure out why what was happening.

It's best practice to "set -e" so we immediately throw an error if the tagging fails, so we don't upload any old images.