### PR TITLE
Revert "default postgres passwords"

### DIFF
--- a/api-tests/database/Dockerfile
+++ b/api-tests/database/Dockerfile
@@ -8,5 +8,4 @@ ADD  docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
 
 # Default values for passwords and database name. Can be overridden on docker run
 ENV POSTGRES_USER gordonuser
-ENV POSTGRES_PASSWORD password
 ENV POSTGRES_DB ddev

--- a/app-packages/database/Dockerfile
+++ b/app-packages/database/Dockerfile
@@ -10,5 +10,4 @@ ADD  docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
 
 # Default values for passwords and database name. Can be overridden on docker run
 ENV POSTGRES_USER gordonuser
-ENV POSTGRES_PASSWORD password
 ENV POSTGRES_DB ddev

--- a/configuration-management/database/Dockerfile
+++ b/configuration-management/database/Dockerfile
@@ -8,5 +8,4 @@ ADD  docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
 
 # Default values for passwords and database name. Can be overridden on docker run
 ENV POSTGRES_USER gordonuser
-ENV POSTGRES_PASSWORD password
 ENV POSTGRES_DB ddev

--- a/ddev-seed/database/Dockerfile
+++ b/ddev-seed/database/Dockerfile
@@ -8,5 +8,4 @@ ADD  docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
 
 # Default values for passwords and database name. Can be overridden on docker run
 ENV POSTGRES_USER gordonuser
-ENV POSTGRES_PASSWORD password
 ENV POSTGRES_DB ddev

--- a/debugging/database/Dockerfile
+++ b/debugging/database/Dockerfile
@@ -8,5 +8,4 @@ ADD  docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
 
 # Default values for passwords and database name. Can be overridden on docker run
 ENV POSTGRES_USER gordonuser
-ENV POSTGRES_PASSWORD password
 ENV POSTGRES_DB ddev

--- a/defensive-programming/database/Dockerfile
+++ b/defensive-programming/database/Dockerfile
@@ -8,5 +8,4 @@ ADD  docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
 
 # Default values for passwords and database name. Can be overridden on docker run
 ENV POSTGRES_USER gordonuser
-ENV POSTGRES_PASSWORD password
 ENV POSTGRES_DB ddev

--- a/docker-compose/database/Dockerfile
+++ b/docker-compose/database/Dockerfile
@@ -8,5 +8,4 @@ ADD  docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
 
 # Default values for passwords and database name. Can be overridden on docker run
 ENV POSTGRES_USER gordonuser
-ENV POSTGRES_PASSWORD password
 ENV POSTGRES_DB ddev

--- a/edit-and-continue/database/Dockerfile
+++ b/edit-and-continue/database/Dockerfile
@@ -8,5 +8,4 @@ ADD  docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
 
 # Default values for passwords and database name. Can be overridden on docker run
 ENV POSTGRES_USER gordonuser
-ENV POSTGRES_PASSWORD password
 ENV POSTGRES_DB ddev

--- a/end-2-end-tests/database/Dockerfile
+++ b/end-2-end-tests/database/Dockerfile
@@ -8,5 +8,4 @@ ADD  docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
 
 # Default values for passwords and database name. Can be overridden on docker run
 ENV POSTGRES_USER gordonuser
-ENV POSTGRES_PASSWORD password
 ENV POSTGRES_DB ddev

--- a/logging/database/Dockerfile
+++ b/logging/database/Dockerfile
@@ -8,5 +8,4 @@ ADD  docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
 
 # Default values for passwords and database name. Can be overridden on docker run
 ENV POSTGRES_USER gordonuser
-ENV POSTGRES_PASSWORD password
 ENV POSTGRES_DB ddev

--- a/unit-tests/database/Dockerfile
+++ b/unit-tests/database/Dockerfile
@@ -8,5 +8,4 @@ ADD  docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
 
 # Default values for passwords and database name. Can be overridden on docker run
 ENV POSTGRES_USER gordonuser
-ENV POSTGRES_PASSWORD password
 ENV POSTGRES_DB ddev


### PR DESCRIPTION
This reverts commit 00cf9e58fbb654df2faa57c470858a3c43746ee1 - turns out postgres doesn't like having the password and password file set at the same time.